### PR TITLE
Link com.android.terminal to jackpal_androidterm

### DIFF
--- a/MainActivity22/app/src/main/assets/icons/res/xml/appfilter.xml
+++ b/MainActivity22/app/src/main/assets/icons/res/xml/appfilter.xml
@@ -228,6 +228,7 @@
 		<item component="ComponentInfo{com.netflix.mediaclient/com.netflix.mediaclient.UIWebViewActivity}" drawable="com_netflix_mediaclient"/>
         <item component="ComponentInfo{com.netflix.mediaclient/com.netflix.mediaclient.UIWebViewTabletActivity}" drawable="com_netflix_mediaclient"/>
 		<item component="ComponentInfo{jackpal.androidterm/jackpal.androidterm.Term}" drawable="jackpal_androidterm"/>
+        <item component="ComponentInfo{com.android.terminal/com.android.terminal.TerminalActivity}" drawable="jackpal_androidterm"/>
 		<item component="ComponentInfo{com.android.camera/com.android.camera.Camera}" drawable="com_android_camera"/>
 		<item component="ComponentInfo{com.android.camera2/com.android.camera.CameraLauncher}" drawable="com_android_camera"/>
         <item component="ComponentInfo{com.google.android.GoogleCamera/com.android.camera.CameraLauncher}" drawable="com_android_camera"/>

--- a/MainActivity22/app/src/main/res/xml/appfilter.xml
+++ b/MainActivity22/app/src/main/res/xml/appfilter.xml
@@ -228,7 +228,8 @@
 		<item component="ComponentInfo{com.netflix.mediaclient/com.netflix.mediaclient.UIWebViewActivity}" drawable="com_netflix_mediaclient"/>
         <item component="ComponentInfo{com.netflix.mediaclient/com.netflix.mediaclient.UIWebViewTabletActivity}" drawable="com_netflix_mediaclient"/>
 		<item component="ComponentInfo{jackpal.androidterm/jackpal.androidterm.Term}" drawable="jackpal_androidterm"/>
-		<item component="ComponentInfo{com.android.camera/com.android.camera.Camera}" drawable="com_android_camera"/>
+        <item component="ComponentInfo{com.android.terminal/com.android.terminal.TerminalActivity}" drawable="jackpal_androidterm"/>
+        <item component="ComponentInfo{com.android.camera/com.android.camera.Camera}" drawable="com_android_camera"/>
 		<item component="ComponentInfo{com.android.camera2/com.android.camera.CameraLauncher}" drawable="com_android_camera"/>
         <item component="ComponentInfo{com.google.android.GoogleCamera/com.android.camera.CameraLauncher}" drawable="com_android_camera"/>
         <item component="ComponentInfo{com.sec.android.app.camera/com.sec.android.app.camera.Camera}" drawable="com_android_camera"/>


### PR DESCRIPTION
This simply adds an icon for `com.android.terminal` by using the existing icon for `jackpal.androidterm`.  `com.android.terminal` is the app created after you enable it in Settings > Developer options > Local terminal. This was tested to work on my Note 2 running CM12 nightlies.

![_20150310_025954](https://cloud.githubusercontent.com/assets/3688847/6571071/083cd8c2-c6d2-11e4-934e-9480f0f61e3a.JPG)
